### PR TITLE
Add performance measurement to round start.

### DIFF
--- a/game/Assets/Scripts/Game/GameData.cs
+++ b/game/Assets/Scripts/Game/GameData.cs
@@ -42,7 +42,7 @@ public class GameData : MonoSingleton<GameData>
     {
         bugs = new List<GameObject>();
 
-        Level = 400;
+        Level = 1;
         Coins = StartCoins;
         HitPoints = StartHitPoints; 
         

--- a/game/Assets/Scripts/Game/GameData.cs
+++ b/game/Assets/Scripts/Game/GameData.cs
@@ -44,7 +44,7 @@ public class GameData : MonoSingleton<GameData>
 
         Level = 1;
         Coins = StartCoins;
-        HitPoints = StartHitPoints; 
+        HitPoints = StartHitPoints;
         
         _eventManager.UpdateCoins();
         _eventManager.UpdateHitPoints();

--- a/game/Assets/Scripts/Game/GameData.cs
+++ b/game/Assets/Scripts/Game/GameData.cs
@@ -42,9 +42,9 @@ public class GameData : MonoSingleton<GameData>
     {
         bugs = new List<GameObject>();
 
-        Level = 1;
+        Level = 400;
         Coins = StartCoins;
-        HitPoints = StartHitPoints;
+        HitPoints = StartHitPoints + 200; 
         
         _eventManager.UpdateCoins();
         _eventManager.UpdateHitPoints();

--- a/game/Assets/Scripts/Game/GameData.cs
+++ b/game/Assets/Scripts/Game/GameData.cs
@@ -44,7 +44,7 @@ public class GameData : MonoSingleton<GameData>
 
         Level = 400;
         Coins = StartCoins;
-        HitPoints = StartHitPoints + 200; 
+        HitPoints = StartHitPoints; 
         
         _eventManager.UpdateCoins();
         _eventManager.UpdateHitPoints();

--- a/game/Assets/Scripts/Game/GameStateFighting.cs
+++ b/game/Assets/Scripts/Game/GameStateFighting.cs
@@ -41,10 +41,8 @@ public class GameStateFighting : GameState
 
     public override void Tick()
     {
-        var stopwatch = new Stopwatch();
-        stopwatch.Start();
         base.Tick();
-
+        var frameDeltaTime = Time.deltaTime;
         timer += Time.deltaTime;
         if (bugsToSpawn > 0 && timer > 0.3f)
         {
@@ -61,12 +59,11 @@ public class GameStateFighting : GameState
             }
         }
         
-        stopwatch.Stop();
-        if (stopwatch.ElapsedMilliseconds > 1000)
+        if (frameDeltaTime >= 0.3f)
         {
-            stalledFrames++;
+            stalledFrames++; 
         }
-        else if(stopwatch.ElapsedMilliseconds >= 100)
+        else if(frameDeltaTime >= 0.01f)
         { 
             slowFrames++;
         }

--- a/game/Assets/Scripts/Game/GameStateFighting.cs
+++ b/game/Assets/Scripts/Game/GameStateFighting.cs
@@ -12,9 +12,9 @@ public class GameStateFighting : GameState
     private GameData _data;
     private int bugsToSpawn;
     private float timer = 0f;
-    int slowFrames = 0;
-    int stalledFrames = 0;
-    int totalFrames = 0;
+    private int _slowFrames = 0;
+    private int _frozenFrames = 0;
+    private int _totalFrames = 0;
     private ITransaction _roundStartTransaction = null;
 
     public GameStateFighting(GameStateMachine stateMachine) : base(stateMachine)
@@ -30,9 +30,9 @@ public class GameStateFighting : GameState
         _roundStartTransaction = SentrySdk.StartTransaction("round.start", "Start Round");
         SentrySdk.ConfigureScope(scope => scope.Transaction = _roundStartTransaction);
 
-        slowFrames = 0;
-        stalledFrames = 0;
-        totalFrames = 0;
+        _slowFrames = 0;
+        _frozenFrames = 0;
+        _totalFrames = 0;
 
         base.OnEnter();
         
@@ -61,21 +61,21 @@ public class GameStateFighting : GameState
         
         if (frameDeltaTime >= 0.3f)
         {
-            stalledFrames++; 
+            _frozenFrames++; 
         }
         else if(frameDeltaTime >= 0.01f)
         { 
-            slowFrames++;
+            _slowFrames++;
         }
-        totalFrames++;
+        _totalFrames++;
         if (_roundStartTransaction is { } startTransaction && bugsToSpawn <= 0)
         {
             _bugSpawner.FinishChildSpan();
 
             // TODO: Send as measurements
-            startTransaction.SetExtra("frames_total", totalFrames.ToString());
-            startTransaction.SetExtra("frames_slow", slowFrames.ToString());
-            startTransaction.SetExtra("frames_frozen", stalledFrames.ToString());
+            startTransaction.SetExtra("frames_total", _totalFrames.ToString());
+            startTransaction.SetExtra("frames_slow", _slowFrames.ToString());
+            startTransaction.SetExtra("frames_frozen", _frozenFrames.ToString());
             startTransaction.Finish(SpanStatus.Ok);
             _roundStartTransaction = null;
         }

--- a/game/Assets/Scripts/Game/GameStateFighting.cs
+++ b/game/Assets/Scripts/Game/GameStateFighting.cs
@@ -28,14 +28,13 @@ public class GameStateFighting : GameState
         bugsToSpawn = 5 + _data.Level * 2;
     } 
 
-    public override void Tick() 
+    public override void Tick()
     {
         base.Tick();
 
         timer += Time.deltaTime;
         if (bugsToSpawn > 0 && timer > 0.3f)
         {
-
             timer = 0;
             for (int i = 0; i < _data.Level; i++)
             {
@@ -45,10 +44,10 @@ public class GameStateFighting : GameState
                 if (bugsToSpawn == 0)
                 {
                     break;
-                } 
+                }
             }
-            RoundStarted?.Finish(SpanStatus.Ok);
-            RoundStarted = null;
+            _roundStartTransaction?.Finish(SpanStatus.Ok);
+            _roundStartTransaction = null;
         }
 
         if (_data.HitPoints <= 0)
@@ -60,7 +59,7 @@ public class GameStateFighting : GameState
         if (_data.bugs.Count <= 0 && bugsToSpawn == 0)
         {
             _data.Level++;
-            StateTransition(GameStates.Upgrading); 
+            StateTransition(GameStates.Upgrading);
             return;
         }
     }

--- a/game/Assets/Scripts/Game/GameStateFighting.cs
+++ b/game/Assets/Scripts/Game/GameStateFighting.cs
@@ -71,6 +71,8 @@ public class GameStateFighting : GameState
         totalFrames++;
         if (bugsToSpawn <= 0)
         {
+            _bugSpawner.FinishChildSpan();
+
             _roundStartTransaction?.SetExtra("frames_total", totalFrames.ToString());
             _roundStartTransaction?.SetExtra("frames_slow", slowFrames.ToString()); 
             _roundStartTransaction?.SetExtra("frames_frozen", stalledFrames.ToString()); 

--- a/game/Assets/Scripts/Manager/BugSpawner.cs
+++ b/game/Assets/Scripts/Manager/BugSpawner.cs
@@ -39,7 +39,7 @@ public class BugSpawner : MonoSingleton<BugSpawner>
         _startUpTask = RetrieveSentryBugs();
     }
 
-    private void OnDestroy()  
+    private void OnDestroy()
     {
         _client.Dispose();
     }

--- a/game/Assets/Scripts/Manager/BugSpawner.cs
+++ b/game/Assets/Scripts/Manager/BugSpawner.cs
@@ -53,8 +53,7 @@ public class BugSpawner : MonoSingleton<BugSpawner>
 
     private async Task RetrieveSentryBugs()
     {
-        _spawnChild?.Finish(SpanStatus.Ok);
-        _spawnChild = null;
+        FinishChildSpan();
         var data = await _client.GetStringAsync(
             "https://europe-west3-nth-wording-322409.cloudfunctions.net/sentry-game-server").ConfigureAwait(false);
 
@@ -80,6 +79,12 @@ public class BugSpawner : MonoSingleton<BugSpawner>
 
         _sentryBugs.TryPop(out var bug);
         return bug;
+    }
+
+    public void FinishChildSpan()
+    {
+        _spawnChild?.Finish(SpanStatus.Ok);
+        _spawnChild = null;
     }
 
     public GameObject Spawn()

--- a/game/Assets/Scripts/Manager/BugSpawner.cs
+++ b/game/Assets/Scripts/Manager/BugSpawner.cs
@@ -71,7 +71,7 @@ public class BugSpawner : MonoSingleton<BugSpawner>
             _startUpTask.GetAwaiter().GetResult();
         }
 
-        if (_sentryBugs.Count <= 0) 
+        if (_sentryBugs.Count <= 0)
         {
             _startUpTask = RetrieveSentryBugs();
             _startUpTask.GetAwaiter().GetResult();


### PR DESCRIPTION
This PR creates Transactions that measure the time it took to load all the bugs, additionally, it also measures the amount of time it took to talk with the GCP Function.

#skip-changelog.

screenshot:

![image](https://user-images.githubusercontent.com/8229322/138931253-8db318c7-da87-459b-93fb-ced8bcb807e3.png)
