### PR TITLE
add SentryTower as InApp:true

### DIFF
--- a/game/Assets/Scripts/SentryRuntimeConfiguration.cs
+++ b/game/Assets/Scripts/SentryRuntimeConfiguration.cs
@@ -14,6 +14,7 @@ public class SentryRuntimeConfiguration : Sentry.Unity.SentryRuntimeOptionsConfi
         // Take a look at `SentryBuildTimeOptionsConfiguration` instead.
         // TODO implement
 
+        options.AddInAppExcludeRegex(".*SentryTower.*"); // Sentry marks things started with 'Sentry' as InApp=false
         options.SetBeforeBreadcrumb((breadcrumb, hint) =>
         {
             if (breadcrumb.Category == "http")

--- a/game/Assets/Scripts/SentryRuntimeConfiguration.cs
+++ b/game/Assets/Scripts/SentryRuntimeConfiguration.cs
@@ -14,7 +14,7 @@ public class SentryRuntimeConfiguration : Sentry.Unity.SentryRuntimeOptionsConfi
         // Take a look at `SentryBuildTimeOptionsConfiguration` instead.
         // TODO implement
 
-        options.AddInAppExcludeRegex(".*SentryTower.*"); // Sentry marks things started with 'Sentry' as InApp=false
+        options.AddInAppIncludeRegex(".*SentryTower.*"); // Sentry marks things started with 'Sentry' as InApp=false
         options.SetBeforeBreadcrumb((breadcrumb, hint) =>
         {
             if (breadcrumb.Category == "http")


### PR DESCRIPTION
Looks like we match against `module` so I guess this should work ( didn't test it 😬 )

[Example event](https://sentry.sentry.io/issues/5987979673/?node=txn-686909f967734721b795248d0484ea2d&project=5905698&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=1)

Top frame was not showing (and link to GitHub doesn't render) because we mark it as InApp:false
<img width="918" alt="image" src="https://github.com/user-attachments/assets/e1aac2c4-cd6d-4d4a-9136-916c361e6bce">

Happened on issue:
* https://github.com/getsentry/sentry-defenses/issues/20

```json
{
"function": "OnReset",
"symbol": "SentryTower_OnReset_mFE6A942292A8D8C2865447CCB685B638E6CD295E",
"module": "SentryTower",
"package": "Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
"filename": "SentryTower.cs",
"abs_path": "[/Users/bruno/git/sentry-defenses/game/Assets/Scripts/Sentry/SentryTower.cs](https://us.sentry.io/Users/bruno/git/sentry-defenses/game/Assets/Scripts/Sentry/SentryTower.cs)",
"lineno": 68,
"pre_context": [
"        _eventManager.OnGameResume -= OnResume;",
"    }",
"",
"    private void OnReset()",
"    {"
],
"context_line": "        if (gameObject == null)",
"post_context": [
"        {",
"            return;",
"        }",
"        ",
"        if (gameObject.CompareTag(\"Turd\"))"
],
"in_app": false,
"data": {
"symbolicator_status": "symbolicated"
},
"instruction_addr": "0x800000000105157c"
}
```
